### PR TITLE
Skip undefined nodes by default

### DIFF
--- a/src/Node/Block/CodeBlock.php
+++ b/src/Node/Block/CodeBlock.php
@@ -29,7 +29,7 @@ class CodeBlock extends BlockNode implements JsonSerializable
         $this->language = $language;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data, ['attrs']);
 
@@ -38,6 +38,9 @@ class CodeBlock extends BlockNode implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Block/Expand.php
+++ b/src/Node/Block/Expand.php
@@ -56,7 +56,7 @@ class Expand extends BlockNode implements JsonSerializable
         $this->title = $title;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data, ['attrs']);
         self::checkRequiredKeys(['title'], $data['attrs']);
@@ -66,6 +66,9 @@ class Expand extends BlockNode implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Block/Heading.php
+++ b/src/Node/Block/Heading.php
@@ -31,7 +31,7 @@ class Heading extends BlockNode implements JsonSerializable
         $this->level = $level;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data, ['attrs']);
         self::checkRequiredKeys(['level'], $data['attrs']);
@@ -41,6 +41,9 @@ class Heading extends BlockNode implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Block/MediaSingle.php
+++ b/src/Node/Block/MediaSingle.php
@@ -52,7 +52,7 @@ class MediaSingle extends BlockNode implements JsonSerializable
         $this->width = $width;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data, ['attrs']);
         self::checkRequiredKeys(['layout'], $data['attrs']);
@@ -62,6 +62,9 @@ class MediaSingle extends BlockNode implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Block/OrderedList.php
+++ b/src/Node/Block/OrderedList.php
@@ -29,7 +29,7 @@ class OrderedList extends BlockNode implements JsonSerializable
         $this->order = $order;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data);
 
@@ -38,6 +38,9 @@ class OrderedList extends BlockNode implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Block/Panel.php
+++ b/src/Node/Block/Panel.php
@@ -53,7 +53,7 @@ class Panel extends BlockNode
         $this->panelType = $type;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data, ['attrs']);
         self::checkRequiredKeys(['panelType'], $data['attrs']);
@@ -63,6 +63,9 @@ class Panel extends BlockNode
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Block/Table.php
+++ b/src/Node/Block/Table.php
@@ -45,7 +45,7 @@ class Table extends BlockNode
         $this->localId = $localId;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data, ['attrs']);
         self::checkRequiredKeys(['layout', 'isNumberColumnEnabled'], $data['attrs']);
@@ -55,6 +55,9 @@ class Table extends BlockNode
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -19,7 +19,13 @@ abstract class BlockNode extends Node
         return $result;
     }
 
-    public static function load(array $data, ?self $parent = null): self
+    /**
+     * @param array $data ADF-Array
+     * @param BlockNode|null $parent Parent-Node, set to 'null' if none
+     * @param bool $skipUndefined Set to 'false' to throw exception for undefined nodes (default: 'true')
+     * @return self
+     */
+    public static function load(array $data, ?self $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data);
 
@@ -37,6 +43,9 @@ abstract class BlockNode extends Node
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($nodeData['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 
@@ -45,6 +54,23 @@ abstract class BlockNode extends Node
         }
 
         return $node;
+    }
+
+    /**
+     * Check if node type is valid
+     * @param string $nodeType
+     * @param bool $skipException
+     * @return bool True if valid node type
+     */
+    public static function checkNodeType(string $nodeType, bool $skipException): bool
+    {
+        if(!\array_key_exists($nodeType, Node::NODE_MAPPING)) {
+            if (!$skipException) {
+                throw new InvalidArgumentException(sprintf('Invalid node type "%s"', $nodeType));
+            }
+            return false;
+        }
+        return true;
     }
 
     public function getContent(): array

--- a/src/Node/Child/TableCell.php
+++ b/src/Node/Child/TableCell.php
@@ -72,7 +72,7 @@ class TableCell extends BlockNode implements JsonSerializable
         $this->colwidth = $colwidth;
     }
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data);
 
@@ -87,6 +87,9 @@ class TableCell extends BlockNode implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/src/Node/Child/TableHeader.php
+++ b/src/Node/Child/TableHeader.php
@@ -15,7 +15,7 @@ class TableHeader extends TableCell implements JsonSerializable
 {
     protected string $type = 'tableHeader';
 
-    public static function load(array $data, ?BlockNode $parent = null): self
+    public static function load(array $data, ?BlockNode $parent = null, bool $skipUndefined = true): self
     {
         self::checkNodeData(static::class, $data);
 
@@ -30,6 +30,9 @@ class TableHeader extends TableCell implements JsonSerializable
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                if (!self::checkNodeType($data['type'], $skipUndefined))
+                    continue;
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 


### PR DESCRIPTION
- undefined nodes are now skipped by default when calling `load()` (instead of throwing exception)
- new parameter for `load()`: `$skipUndefined` - set to `false` to throw exception when an undefined node is encountered